### PR TITLE
Permit negative resource IDs

### DIFF
--- a/Support/Examples/NegativeResourceIDTest.kdl
+++ b/Support/Examples/NegativeResourceIDTest.kdl
@@ -1,0 +1,48 @@
+@type Engine : "ëngn" {
+    template {
+        DWRD torque;
+        DWRD power;
+    };
+
+    field("torque") {
+        torque;
+    };
+
+    field("power") {
+        power;
+    };
+};
+
+@type Vehicle : "äuto" {
+    template {
+        DWRD engine;
+        PSTR name;
+    };
+
+    field("engine"){
+        engine as Engine&;
+    };
+
+    field("name") {
+        name;
+    };
+};
+
+declare Engine {
+    new (#128) {
+        torque = 320;
+        power = 103;
+    };
+};
+
+declare Vehicle {
+    new (#128, "Car") {
+        name = "Car";
+        engine = #128;
+    };
+
+    new (#129, "Trailer") {
+        name = "Trailer";
+        engine = #-1;
+    };
+};

--- a/src/parser/lexer.cpp
+++ b/src/parser/lexer.cpp
@@ -80,6 +80,11 @@ auto kdl::lexer::analyze() -> std::vector<lexeme>
         else if (test_if(match<'#'>::yes)) {
             // We're looking at a resource id.
             advance();
+            auto negative = test_if(match<'-'>::yes);
+            if (negative) {
+                advance();
+            }
+
             consume_while(decimal_set::contains);
             m_lexemes.emplace_back(kdl::lexeme(m_slice, lexeme::res_id, m_pos, m_offset, m_line, m_source));
         }


### PR DESCRIPTION
When compiling `Ship.kdl` the following error is shown:

```
$ kdl/bin/kdl -o kdl-out/ kdl-nova/Types/Ship.kdl 
kdl-nova/Types/Ship.kdl:L385:65 - Could not ensure the correctness of the token '1'
```

The issue is with the following field specification:

```
DefaultItems<$FieldNumber> as Outfit& = None [ None = #-1 ];
```

Here, a resource ID of `#-1` is used to indicate no value is present.

This change permits negative resource IDs and allows `Ship.kdl` to compile without error.