### PR TITLE
Support negative integer literals

### DIFF
--- a/Support/Examples/NegativeNumbersTest.kdl
+++ b/Support/Examples/NegativeNumbersTest.kdl
@@ -1,0 +1,20 @@
+@type NegativeNumbersTest : "Ntst" {
+    template {
+        DWRD value;
+        DWRD defaultValue;
+    };
+
+    field("value") {
+        value as Range<-1, 63>;
+    };
+
+    field("defaultValue") {
+        defaultValue = -5;
+    };
+};
+
+declare NegativeNumbersTest {
+    new (#128) {
+        value = -1;
+    };
+};

--- a/src/parser/lexeme.hpp
+++ b/src/parser/lexeme.hpp
@@ -178,18 +178,20 @@ namespace kdl
         template<typename T, typename std::enable_if<std::is_arithmetic<T>::value>::type* = nullptr>
         auto value() const -> T
         {
-           if (m_text.size() >= 3 && (m_text.substr(0, 2) == "0x" || m_text.substr(0, 2) == "0X")) {
+            if (m_text.size() >= 2 && m_text[0] == '-') {
+               // Negative decimal
+               return static_cast<T>(std::stoll(m_text, nullptr, 10));
+            }
+            else if (m_text.size() >= 3 && (m_text.substr(0, 2) == "0x" || m_text.substr(0, 2) == "0X")) {
                // Hex
                return static_cast<T>(std::stoull(m_text.substr(2), nullptr, 16));
-           }
-           else {
+            }
+            else {
                // Decimal
                return static_cast<T>(std::stoull(m_text, nullptr, 10));
            }
         }
-
     };
-
 };
 
 #endif //KDL_LEXEME_HPP

--- a/src/parser/lexer.cpp
+++ b/src/parser/lexer.cpp
@@ -86,7 +86,12 @@ auto kdl::lexer::analyze() -> std::vector<lexeme>
             }
 
             consume_while(decimal_set::contains);
-            m_lexemes.emplace_back(kdl::lexeme(m_slice, lexeme::res_id, m_pos, m_offset, m_line, m_source));
+            if (negative) {
+                m_lexemes.emplace_back(kdl::lexeme("-" + m_slice, lexeme::res_id, m_pos, m_offset, m_line, m_source));
+            }
+            else {
+                m_lexemes.emplace_back(kdl::lexeme(m_slice, lexeme::res_id, m_pos, m_offset, m_line, m_source));
+            }
         }
         else if (test_if(match<'$'>::yes)) {
             // We're looking at a variable.
@@ -109,14 +114,17 @@ auto kdl::lexer::analyze() -> std::vector<lexeme>
 
             consume_while(decimal_set::contains);
             auto number_text = m_slice;
+            if (negative) {
+                number_text = "-" + number_text;
+            }
 
             if (test_if(match<'%'>::yes)) {
                 // This is a percentage.
                 advance();
-                m_lexemes.emplace_back(kdl::lexeme(m_slice, lexeme::percentage, m_pos, m_offset, m_line, m_source));
+                m_lexemes.emplace_back(kdl::lexeme(number_text, lexeme::percentage, m_pos, m_offset, m_line, m_source));
             }
             else {
-                m_lexemes.emplace_back(kdl::lexeme(m_slice, lexeme::integer, m_pos, m_offset, m_line, m_source));
+                m_lexemes.emplace_back(kdl::lexeme(number_text, lexeme::integer, m_pos, m_offset, m_line, m_source));
             }
         }
         else if (test_if(identifier_set::limited_contains)) {


### PR DESCRIPTION
This change adds support for negative decimal integers. Tested using `NegativeNumbersTest.kdl`; confirmed that the negative value set in the range specification is accepted and output, as is the default value, with `FF FF FF FB` appearing for the resource data in Rez format.