### PR TITLE
Add symbol support to implicit and reference values

### DIFF
--- a/Support/Examples/NegativeResourceIDTest.kdl
+++ b/Support/Examples/NegativeResourceIDTest.kdl
@@ -20,7 +20,7 @@
     };
 
     field("engine"){
-        engine as Engine&;
+        engine as Engine& [ None = #-1 ];
     };
 
     field("name") {
@@ -43,6 +43,6 @@ declare Vehicle {
 
     new (#129, "Trailer") {
         name = "Trailer";
-        engine = #-1;
+        engine = None;
     };
 };

--- a/Support/Examples/SymbolTest.kdl
+++ b/Support/Examples/SymbolTest.kdl
@@ -1,0 +1,29 @@
+@type SymbolTest : "SÿTe" {
+    template {
+        DWRD numeric;
+        CSTR string;
+        DWRD multinum;
+        CSTR multistr;
+    };
+
+    field("numeric") {
+        numeric = B [ A = 1, B = 2];
+    };
+
+    field("string") {
+        string = A [ A = "A", B = "B" ];
+    };
+
+    field("multivalue") {
+        multinum = B [ A = 1, B = 2];
+        multistr = A [ A = "A", B = "B" ];
+    };
+};
+
+declare SymbolTest {
+    new (#128) {
+        numeric = A;
+        string = B;
+        multivalue = A B;
+    };
+};

--- a/src/parser/sema/declarations/implicit_value_parser.cpp
+++ b/src/parser/sema/declarations/implicit_value_parser.cpp
@@ -35,96 +35,34 @@ kdl::sema::implicit_value_parser::implicit_value_parser(kdl::sema::parser &parse
 
 auto kdl::sema::implicit_value_parser::parse(kdl::build_target::resource_instance &instance) -> void
 {
-    // Read the next value and write it to the resource.
+    // Validate the type of the next value
+    enum lexeme::type field_type;
+
     switch (m_binary_field.type & ~0xFFF) {
-        case build_target::DBYT: {
-            if (!m_parser.expect({ expectation(lexeme::integer).be_true() })) {
-                auto lx = m_parser.peek();
-                log::fatal_error(lx, 1, "Expected an integer literal for field '" + m_field.name().text() + "'.");
-            }
-            instance.write_signed_byte(m_field, m_field_value, m_parser.read().value<int8_t>());
-            break;
-        }
-        case build_target::DWRD: {
-            if (!m_parser.expect({ expectation(lexeme::integer).be_true() })) {
-                auto lx = m_parser.peek();
-                log::fatal_error(lx, 1, "Expected an integer literal for field '" + m_field.name().text() + "'.");
-            }
-            instance.write_signed_short(m_field, m_field_value, m_parser.read().value<int16_t>());
-            break;
-        }
-        case build_target::DLNG: {
-            if (!m_parser.expect({ expectation(lexeme::integer).be_true() })) {
-                auto lx = m_parser.peek();
-                log::fatal_error(lx, 1, "Expected an integer literal for field '" + m_field.name().text() + "'.");
-            }
-            instance.write_signed_long(m_field, m_field_value, m_parser.read().value<int32_t>());
-            break;
-        }
-        case build_target::DQAD: {
-            if (!m_parser.expect({ expectation(lexeme::integer).be_true() })) {
-                auto lx = m_parser.peek();
-                log::fatal_error(lx, 1, "Expected an integer literal for field '" + m_field.name().text() + "'.");
-            }
-            instance.write_signed_quad(m_field, m_field_value, m_parser.read().value<int64_t>());
-            break;
-        }
-        case build_target::HBYT: {
-            if (!m_parser.expect({ expectation(lexeme::integer).be_true() })) {
-                auto lx = m_parser.peek();
-                log::fatal_error(lx, 1, "Expected an integer literal for field '" + m_field.name().text() + "'.");
-            }
-            instance.write_byte(m_field, m_field_value, m_parser.read().value<uint8_t>());
-            break;
-        }
-        case build_target::HWRD: {
-            if (!m_parser.expect({ expectation(lexeme::integer).be_true() })) {
-                auto lx = m_parser.peek();
-                log::fatal_error(lx, 1, "Expected an integer literal for field '" + m_field.name().text() + "'.");
-            }
-            instance.write_short(m_field, m_field_value, m_parser.read().value<uint16_t>());
-            break;
-        }
-        case build_target::HLNG: {
-            if (!m_parser.expect({ expectation(lexeme::integer).be_true() })) {
-                auto lx = m_parser.peek();
-                log::fatal_error(lx, 1, "Expected an integer literal for field '" + m_field.name().text() + "'.");
-            }
-            instance.write_long(m_field, m_field_value, m_parser.read().value<uint32_t>());
-            break;
-        }
+        case build_target::DBYT:
+        case build_target::DWRD:
+        case build_target::DLNG:
+        case build_target::DQAD:
+        case build_target::HBYT:
+        case build_target::HWRD:
+        case build_target::HLNG:
         case build_target::HQAD: {
-            if (!m_parser.expect({ expectation(lexeme::integer).be_true() })) {
+            field_type = lexeme::integer;
+            if (!m_parser.expect_any({ expectation(lexeme::integer).be_true(), expectation(lexeme::identifier).be_true() })) {
                 auto lx = m_parser.peek();
-                log::fatal_error(lx, 1, "Expected an integer literal for field '" + m_field.name().text() + "'.");
+                log::fatal_error(lx, 1, "Expected an integer literal or symbol for field '" + m_field.name().text() + "'.");
             }
-            instance.write_quad(m_field, m_field_value, m_parser.read().value<uint64_t>());
             break;
         }
 
-        case build_target::PSTR: {
-            if (!m_parser.expect({ expectation(lexeme::string).be_true() })) {
-                auto lx = m_parser.peek();
-                log::fatal_error(lx, 1, "Expected an string literal for field '" + m_field.name().text() + "'.");
-            }
-            instance.write_pstr(m_field, m_field_value, m_parser.read().text());
-            break;
-        }
-        case build_target::CSTR: {
-            if (!m_parser.expect({ expectation(lexeme::string).be_true() })) {
-                auto lx = m_parser.peek();
-                log::fatal_error(lx, 1, "Expected an string literal for field '" + m_field.name().text() + "'.");
-            }
-            instance.write_cstr(m_field, m_field_value, m_parser.read().text());
-            break;
-        }
-
+        case build_target::PSTR:
+        case build_target::CSTR:
         case build_target::Cnnn: {
-            if (!m_parser.expect({ expectation(lexeme::string).be_true() })) {
+            field_type = lexeme::string;
+            if (!m_parser.expect_any({ expectation(lexeme::string).be_true(), expectation(lexeme::identifier).be_true() })) {
                 auto lx = m_parser.peek();
-                log::fatal_error(lx, 1, "Expected an string literal for field '" + m_field.name().text() + "'.");
+                log::fatal_error(lx, 1, "Expected an string literal or symbol for field '" + m_field.name().text() + "'.");
             }
-            instance.write_cstr(m_field, m_field_value, m_parser.read().text(), m_binary_field.type & 0xFFF);
             break;
         }
 
@@ -138,11 +76,6 @@ auto kdl::sema::implicit_value_parser::parse(kdl::build_target::resource_instanc
                 auto lx = m_parser.peek();
                 log::fatal_error(lx, 1, "Expected 4 integer literals for field '" + m_field.name().text() + "'.");
             }
-            instance.write_rect(m_field, m_field_value,
-                                m_parser.read().value<int16_t>(),
-                                m_parser.read().value<int16_t>(),
-                                m_parser.read().value<int16_t>(),
-                                m_parser.read().value<int16_t>());
             break;
         }
 
@@ -152,6 +85,77 @@ auto kdl::sema::implicit_value_parser::parse(kdl::build_target::resource_instanc
 
         case build_target::INVALID: {
             log::fatal_error(m_parser.peek(), 1, "Unknown type encountered in field '" + m_field.name().text() + "'.");
+        }
+    }
+
+    if ((m_binary_field.type & ~0xFFF) == build_target::RECT) {
+        instance.write_rect(m_field, m_field_value,
+                            m_parser.read().value<int16_t>(),
+                            m_parser.read().value<int16_t>(),
+                            m_parser.read().value<int16_t>(),
+                            m_parser.read().value<int16_t>());
+    }
+    else {
+        auto value = m_parser.read();
+        if (value.is(lexeme::identifier)) {
+            auto symbol_value = m_field_value.value_for(value);
+
+            if (!symbol_value.is(field_type)) {
+                auto type_desc = field_type == lexeme::string ? "string" : "integer literal";
+                log::fatal_error(m_parser.peek(), 1, "The field '" + m_field.name().text() + "' expects a " + type_desc + " valued symbol.");
+            }
+
+            value = symbol_value;
+        }
+
+        // Read the next value and write it to the resource.
+        switch (m_binary_field.type & ~0xFFF) {
+            case build_target::DBYT: {
+                instance.write_signed_byte(m_field, m_field_value, value.value<int8_t>());
+                break;
+            }
+            case build_target::DWRD: {
+                instance.write_signed_short(m_field, m_field_value, value.value<int16_t>());
+                break;
+            }
+            case build_target::DLNG: {
+                instance.write_signed_long(m_field, m_field_value, value.value<int32_t>());
+                break;
+            }
+            case build_target::DQAD: {
+                instance.write_signed_quad(m_field, m_field_value, value.value<int64_t>());
+                break;
+            }
+            case build_target::HBYT: {
+                instance.write_byte(m_field, m_field_value, value.value<uint8_t>());
+                break;
+            }
+            case build_target::HWRD: {
+                instance.write_short(m_field, m_field_value, value.value<uint16_t>());
+                break;
+            }
+            case build_target::HLNG: {
+                instance.write_long(m_field, m_field_value, value.value<uint32_t>());
+                break;
+            }
+            case build_target::HQAD: {
+                instance.write_quad(m_field, m_field_value, value.value<uint64_t>());
+                break;
+            }
+
+            case build_target::PSTR: {
+                instance.write_pstr(m_field, m_field_value, value.text());
+                break;
+            }
+            case build_target::CSTR: {
+                instance.write_cstr(m_field, m_field_value, value.text());
+                break;
+            }
+
+            case build_target::Cnnn: {
+                instance.write_cstr(m_field, m_field_value, value.text(), m_binary_field.type & 0xFFF);
+                break;
+            }
         }
     }
 }

--- a/src/parser/sema/declarations/unnamed_reference_value_parser.cpp
+++ b/src/parser/sema/declarations/unnamed_reference_value_parser.cpp
@@ -37,10 +37,20 @@ kdl::sema::unnamed_reference_value_parser::unnamed_reference_value_parser(kdl::s
 
 auto kdl::sema::unnamed_reference_value_parser::parse(kdl::build_target::resource_instance &instance) -> void
 {
-    if (!m_parser.expect({ expectation(lexeme::res_id).be_true() })) {
-        log::fatal_error(m_parser.peek(), 1, "The field '" + m_field.name().text() + "' expects as a resource id.");
+    if (!m_parser.expect_any({ expectation(lexeme::identifier).be_true(), expectation(lexeme::res_id).be_true() })) {
+        log::fatal_error(m_parser.peek(), 1, "The field '" + m_field.name().text() + "' expects a symbol or resource id.");
     }
+
     auto ref = m_parser.read();
+    if (ref.is(lexeme::identifier)) {
+        auto symbol_value = m_field_value.value_for(ref);
+
+        if (!symbol_value.is(lexeme::res_id)) {
+            log::fatal_error(m_parser.peek(), 1, "The field '" + m_field.name().text() + "' expects a resource id valued symbol.");
+        }
+
+        ref = symbol_value;
+    }
 
     // Ensure that the underlying type is correct for a reference.
     switch (m_binary_field.type & ~0xFFF) {


### PR DESCRIPTION
RECT implicit values do not support identifiers (would this be useful?). 