### PR TITLE
Introduce support for a configuration file.

### DIFF
--- a/Support/.kdlconfig
+++ b/Support/.kdlconfig
@@ -1,0 +1,6 @@
+` This is an example configuration file for KDL, that can be used to tell it
+` of certain base configuration information such as where scenario definitions
+` are located.
+@configuration {
+	ScenarioBasePath = "~/.kdl";
+};

--- a/Support/.kdlconfig
+++ b/Support/.kdlconfig
@@ -1,6 +1,0 @@
-` This is an example configuration file for KDL, that can be used to tell it
-` of certain base configuration information such as where scenario definitions
-` are located.
-@configuration {
-	ScenarioBasePath = "~/.kdl";
-};

--- a/Support/SyntaxDefinitions/KDL.sublime-syntax
+++ b/Support/SyntaxDefinitions/KDL.sublime-syntax
@@ -23,10 +23,9 @@
 #
 
 ---
-name: KDL 2 (Kestrel Development Kit)
+name: KDL (Kestrel Development Kit)
 file_extensions:
   - kdl
-  - kdlconfig
 scope: source.kdl
 
 contexts:

--- a/Support/SyntaxDefinitions/KDL.sublime-syntax
+++ b/Support/SyntaxDefinitions/KDL.sublime-syntax
@@ -26,6 +26,7 @@
 name: KDL 2 (Kestrel Development Kit)
 file_extensions:
   - kdl
+  - kdlconfig
 scope: source.kdl
 
 contexts:
@@ -33,12 +34,15 @@ contexts:
     - include: single-line-comment
 
   main:
+    - include: configuration
     - include: directive
     - include: resource-declaration
     - include: string-literal
     - include: number-literal
     - include: resource-literal
     - include: percentage-literal
+    - include: variable-literal
+    - include: identifier-literal
 
 # COMMENTS #####################################################################
 
@@ -61,6 +65,17 @@ contexts:
         - include: string-literal
         - match: ';'
           pop: true
+    - match: '((@)(configuration))'
+      captures:
+        1: keyword.kdl
+      set:
+        - match: '\{'
+          scope: punctuation.definition.type.begin.kdl
+          set:
+            - match: '\};'
+              scope: punctuation.definition.type.end.kdl
+              pop: true
+            - include: configuration-key-value
     - match: '((@)(type))[ \t]+([A-Za-z_][A-Za-z0-9_]*)[ \t]*\:[ \t]*(".{4}")'
       captures:
         1: keyword.kdl
@@ -76,6 +91,22 @@ contexts:
             - include: template-definition
             - include: assertion-rule
             - include: field-definition
+
+# CONFIGURATION ################################################################
+
+  configuration-key-value:
+    - match: '([A-Za-z0-9_]+)[ \t]*\=[ \t]*'
+      captures:
+        1: entity.other.attribute-name.kdl
+      push:
+        - include: string-literal
+        - include: identifier-literal
+        - include: number-literal
+        - include: resource-literal
+        - include: percentage-literal
+        - match: ';'
+          pop: true
+
 
 # TYPE DEFINITION ##############################################################
 

--- a/Support/example.config.kdl
+++ b/Support/example.config.kdl
@@ -1,0 +1,31 @@
+` This is an example configuration file for KDL, that can be used to tell it
+` of certain base configuration information such as where scenario definitions
+` are located.
+@configuration {
+	ScenarioBasePath = "~/.kdl";
+};
+
+` Provide some baked in types.
+@type MachintoshPicture : "PICT" {
+	template {
+		HEXD Data;
+	};
+
+	field("TGA") {
+		` The data should be imported from an image file and converted to a 
+		` PICT format. The
+		Data as File<TGA> __conversion($InputFormat, PICT);
+	};
+};
+
+@type MachintoshColorIcon : "cicn" {
+	template {
+		HEXD Data;
+	};
+
+	field("TGA") {
+		` The data should be imported from an image file and converted to a 
+		` PICT format. The
+		Data as File<TGA> __conversion($InputFormat, cicn);
+	};
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,13 +31,25 @@ auto main(int argc, const char **argv) -> int
     auto target = std::make_shared<kdl::target>();
     std::vector<std::shared_ptr<kdl::file>> files;
 
+    // Load in the default system configuration.
+    // TODO: The configuration file should be located in a different location on Windows.
+    auto configuration_file = std::make_shared<kdl::file>("~/.config.kdl");
+    target->set_src_root(configuration_file->path());
+    kdl::sema::parser(target, kdl::lexer(configuration_file).analyze()).parse();
+
     // Parse the arguments supplied to the program.
     for (auto i = 1; i < argc; ++i) {
         // Check for assembler options
         if (argv[i][0] == '-') {
             std::string arg(argv[i]);
 
-            if (arg == "-v" || arg == "--version") {
+            if (arg == "--configuration") {
+                // Specify a configuration file to load over the top of the previous configuration.
+                configuration_file = std::make_shared<kdl::file>("~/.config.kdl");
+                target->set_src_root(configuration_file->path());
+                kdl::sema::parser(target, kdl::lexer(configuration_file).analyze()).parse();
+            }
+            else if (arg == "-v" || arg == "--version") {
                 // Display the version information to the user
                 std::cout << "KDL Version " << KDL_VERSION << std::endl;
                 std::cout << "\t" << KDL_LICENSE << " " << KDL_AUTHORS << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,6 +63,16 @@ auto main(int argc, const char **argv) -> int
                 // Make we skip over the parameter.
                 i += 1;
             }
+            else if (arg == "-s" || arg == "--scenario") {
+                // Look up the scenario and load it.
+                std::string scenario_name(argv[i + 1]);
+                i += 1;
+                
+                auto scenario_manifest = target->scenario_manifest(scenario_name);
+                auto manifest_file = std::make_shared<kdl::file>(scenario_manifest);
+                target->set_src_root(manifest_file->path());
+                kdl::sema::parser(target, kdl::lexer(manifest_file).analyze()).parse();
+            }
             else if (arg == "-tmpl" && i + 2 < argc) {
                 // Read in a resource file and build KDL definitions from them.
                 std::string res_in(argv[i + 1]);

--- a/src/parser/file.cpp
+++ b/src/parser/file.cpp
@@ -2,10 +2,77 @@
 // Created by Tom Hancocks on 03/04/2020.
 //
 
+#include <sys/stat.h>
+#include <unistd.h>
+#include <pwd.h>
 #include <fstream>
 #include <streambuf>
 #include <iostream>
 #include "parser/file.hpp"
+
+// MARK: - Helpers
+
+auto kdl::file::exists(std::string_view path) -> bool
+{
+    struct stat buffer {};
+    return (stat(std::string(path).c_str(), &buffer) == 0);
+}
+
+auto kdl::file::is_directory(std::string_view path) -> bool
+{
+    struct stat buffer {};
+    return (stat(std::string(path).c_str(), &buffer) == 0 && S_ISDIR(buffer.st_mode));
+}
+
+auto kdl::file::create_directory(std::string_view path) -> void
+{
+    mkdir(std::string(path).c_str(), 0700);
+}
+
+auto kdl::file::resolve_tilde(std::string_view path) -> std::string
+{
+    if (path.length() == 0 || path[0] != '~') {
+        return std::string(path);
+    }
+
+    std::optional<std::string> home;
+    std::size_t pos = path.find_first_of('/');
+
+    if (path.length() == 1 || pos == 1) {
+        if (auto value = getenv("HOME")) {
+            home = std::string(value);
+        }
+        else {
+            struct passwd *pw = getpwuid(getuid());
+            if (pw && pw->pw_dir) {
+                home = std::string(pw->pw_dir);
+            }
+        }
+    }
+    else {
+        std::string user(path, 1, (pos == std::string::npos) ? std::string::npos : pos - 1);
+        struct passwd *pw = getpwnam(user.c_str());
+        if (pw && pw->pw_dir) {
+            home = std::string(pw->pw_dir);
+        }
+    }
+
+    if (!home.has_value()) {
+        return std::string(path);
+    }
+
+    std::string result(home.value());
+    if (pos == std::string::npos) {
+        return result;
+    }
+
+    if (result.length() == 0 || result[result.length() - 1] != '/') {
+        result.append("/");
+    }
+
+    result.append(path.substr(pos + 1));
+    return result;
+}
 
 // MARK: - Constructors
 
@@ -15,19 +82,24 @@ kdl::file::file()
 
 }
 
-kdl::file::file(const std::string path)
-    : m_path(path)
+kdl::file::file(std::string_view path)
+    : m_path(resolve_tilde(path))
 {
-    std::ifstream f(m_path);
+    if (exists(m_path)) {
+        std::ifstream f(m_path);
 
-    // Reserve space in the m_contents string, equivalent to the length of the file.
-    f.seekg(0, std::ios::end);
-    m_contents.reserve(f.tellg());
-    f.seekg(0, std::ios::beg);
+        // Reserve space in the m_contents string, equivalent to the length of the file.
+        f.seekg(0, std::ios::end);
+        m_contents.reserve(f.tellg());
+        f.seekg(0, std::ios::beg);
 
-    // Read in the contents of the file.
-    m_contents.assign(std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>());
-    m_contents += "\n";
+        // Read in the contents of the file.
+        m_contents.assign(std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>());
+        m_contents += "\n";
+    }
+    else {
+        m_contents = "";
+    }
 }
 
 // MARK: - Accessors
@@ -52,7 +124,7 @@ auto kdl::file::set_contents(const std::string contents) -> void
 auto kdl::file::save(std::optional<std::string> path) -> void
 {
     if (path.has_value()) {
-        m_path = path.value();
+        m_path = resolve_tilde(path.value());
     }
 
     if (m_path.empty()) {

--- a/src/parser/file.hpp
+++ b/src/parser/file.hpp
@@ -17,6 +17,12 @@ namespace kdl
      */
     struct file
     {
+    public:
+        static auto exists(std::string_view path) -> bool;
+        static auto is_directory(std::string_view path) -> bool;
+        static auto create_directory(std::string_view path) -> void;
+        static auto resolve_tilde(std::string_view path) -> std::string;
+
     private:
         std::string m_path;
         std::string m_contents;
@@ -31,7 +37,7 @@ namespace kdl
          * Read the specified file from disk.
          * @param path The path from with the load the file.
          */
-        file(const std::string path);
+        file(std::string_view path);
 
         /**
          * The location of the file on disk. Will be empty if this is a blank file.

--- a/src/parser/sema/directives/configuration_directive_parser.cpp
+++ b/src/parser/sema/directives/configuration_directive_parser.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2020 Tom Hancocks
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "diagnostic/fatal.hpp"
+#include "parser/lexer.hpp"
+#include "parser/sema/directives/configuration_directive_parser.hpp"
+
+// MARK: - Parser
+
+auto kdl::sema::configuration_directive_parser::parse(parser &parser, std::weak_ptr<target> target) -> void
+{
+    if (target.expired()) {
+        throw std::logic_error("Build target has expired. This is a bug!");
+    }
+    auto t = target.lock();
+
+    parser.ensure({ expectation(lexeme::l_brace).be_true() });
+
+    while (parser.expect({ expectation(lexeme::r_brace).be_false() })) {
+        if (!parser.expect({ expectation(lexeme::identifier).be_true() })) {
+            log::fatal_error(parser.peek(), 1, "Expected an identifier for configuration key.");
+        }
+        auto key = parser.read().text();
+
+        parser.ensure({ expectation(lexeme::equals).be_true() });
+
+        if (key == "ScenarioBasePath") {
+            if (!parser.expect({ expectation(lexeme::string).be_true() })) {
+                log::fatal_error(parser.peek(), 1, "ScenarioBasePath requires a string value.");
+            }
+            t->set_scenario_root(parser.read().text());
+        }
+        else {
+            log::fatal_error(parser.peek(), 1, "Unrecognised configuration key '" + key + "'.");
+        }
+
+        parser.ensure({ expectation(lexeme::semi).be_true() });
+    }
+
+    parser.ensure({ expectation(lexeme::r_brace).be_true() });
+}

--- a/src/parser/sema/directives/configuration_directive_parser.hpp
+++ b/src/parser/sema/directives/configuration_directive_parser.hpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2020 Tom Hancocks
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#if !defined(KDL_CONFIGURATION_DIRECTIVE_PARSER_HPP)
+#define KDL_CONFIGURATION_DIRECTIVE_PARSER_HPP
+
+#include "parser/parser.hpp"
+
+namespace kdl { namespace sema {
+
+    class configuration_directive_parser
+    {
+    public:
+        static auto parse(parser& parser, std::weak_ptr<target> target) -> void;
+    };
+
+}};
+
+#endif //KDL_CONFIGURATION_DIRECTIVE_PARSER_HPP

--- a/src/parser/sema/directives/directive_parser.cpp
+++ b/src/parser/sema/directives/directive_parser.cpp
@@ -22,6 +22,7 @@
 #include "parser/sema/directives/directive_parser.hpp"
 #include "parser/sema/directives/out_directive_parser.hpp"
 #include "parser/sema/directives/import_directive_parser.hpp"
+#include "parser/sema/directives/configuration_directive_parser.hpp"
 
 // MARK: - Constructor
 
@@ -45,6 +46,9 @@ auto kdl::sema::asm_directive::parse() -> void
     }
     else if (directive.text() == "import") {
         import_directive_parser::parse(m_parser, m_target);
+    }
+    else if (directive.text() == "configuration") {
+        configuration_directive_parser::parse(m_parser, m_target);
     }
     else {
         log::fatal_error(directive, 1, "Unrecognised directive '" + directive.text() + "'");

--- a/src/target/target.cpp
+++ b/src/target/target.cpp
@@ -22,6 +22,7 @@
 #include <unistd.h>
 #include "target/target.hpp"
 #include "diagnostic/fatal.hpp"
+#include "parser/file.hpp"
 
 // MARK: - Constructors
 
@@ -61,35 +62,18 @@ auto kdl::target::type_container_named(const kdl::lexeme name) const -> build_ta
 
 // MARK: - Destination Paths
 
-static inline auto __exists(const std::string& path) -> bool
-{
-    struct stat buffer;
-    return (stat(path.c_str(), &buffer) == 0);
-}
-
-static inline auto __is_directory(const std::string& path) -> bool
-{
-    struct stat buffer;
-    return (stat(path.c_str(), &buffer) == 0 && S_ISDIR(buffer.st_mode));
-}
-
-static inline auto __make_directory(const std::string& path) -> void
-{
-    mkdir(path.c_str(), 0700);
-}
-
 auto kdl::target::set_dst_path(const std::string dst_path) -> void
 {
     auto path = dst_path;
     std::string filename;
 
-    if (__exists(path) && !__is_directory(path)) {
+    if (kdl::file::exists(path) && !kdl::file::is_directory(path)) {
         while (path.substr(path.size() - 1) != "/") {
             filename = path.substr(path.size() - 1) + filename;
             path.pop_back();
         }
     }
-    else if (__exists(path) && __is_directory(path)) {
+    else if (kdl::file::exists(path) && kdl::file::is_directory(path)) {
         filename = "result";
     }
     else {
@@ -98,8 +82,8 @@ auto kdl::target::set_dst_path(const std::string dst_path) -> void
             path.pop_back();
         }
 
-        if (!__exists(path)) {
-            __make_directory(path);
+        if (!kdl::file::exists(path)) {
+            kdl::file::is_directory(path);
         }
     }
 
@@ -110,6 +94,13 @@ auto kdl::target::set_dst_path(const std::string dst_path) -> void
 
     m_dst_root = path;
     m_dst_file = filename;
+}
+
+// MARK: - Scenario Paths
+
+auto kdl::target::set_scenario_root(const std::string path) -> void
+{
+    m_scenario_root = path;
 }
 
 // MARK: - Source Paths
@@ -135,7 +126,10 @@ auto kdl::target::set_src_root(const std::string src_root) -> void
 
 auto kdl::target::resolve_src_path(const std::string path) const -> std::string
 {
-    std::string rpath("@rpath");
+    // TODO: Improve this so it actually makes more sense.
+    std::string rpath("@rpath"); // Root Path (Location of Input File)
+    std::string spath("@spath"); // Scenario Path (Location of Scenario Type Definitions)
+    std::string opath("@opath"); // Output Path (Location of Target Output)
 
     if (path.substr(0, rpath.size()) == rpath) {
         return m_src_root + path.substr(rpath.size());

--- a/src/target/target.hpp
+++ b/src/target/target.hpp
@@ -41,6 +41,7 @@ namespace kdl
         std::string m_dst_root;
         std::string m_dst_file;
         std::string m_src_root;
+        std::string m_scenario_root;
         graphite::rsrc::file::format m_format { graphite::rsrc::file::format::classic };
         std::vector<build_target::type_container> m_type_containers;
         graphite::rsrc::file m_file;
@@ -51,6 +52,8 @@ namespace kdl
         target();
 
         auto set_dst_path(const std::string dst_path) -> void;
+
+        auto set_scenario_root(const std::string path) -> void;
 
         auto set_src_root(const std::string src_root) -> void;
         auto resolve_src_path(const std::string path) const -> std::string;

--- a/src/target/target.hpp
+++ b/src/target/target.hpp
@@ -53,7 +53,8 @@ namespace kdl
 
         auto set_dst_path(const std::string dst_path) -> void;
 
-        auto set_scenario_root(const std::string path) -> void;
+        auto set_scenario_root(std::string_view path) -> void;
+        auto scenario_manifest(std::string_view scenario_name) -> std::string;
 
         auto set_src_root(const std::string src_root) -> void;
         auto resolve_src_path(const std::string path) const -> std::string;


### PR DESCRIPTION
The configuration will form the basis of persistent configuration for KDL, such as where scenario type definitions are located.

By default KDL will look for scenarios in the `~/.kdl` directory, but if a `~/.config.kdl` is specified, and it includes a scenario root, then that will be used instead.