### PR TITLE
Add basic list/repeating template field support

### DIFF
--- a/Support/Examples/StrNTest.kdl
+++ b/Support/Examples/StrNTest.kdl
@@ -1,0 +1,18 @@
+@type StringList : "STR#" {
+    template {
+        OCNT stringcount;
+        PSTR string;
+    };
+
+    field("String") repeatable<0, 65535> {
+        string;
+    };
+};
+
+declare StringList {
+    new(#128) {
+        String = "a";
+        String = "b";
+        String = "c";
+    };
+};

--- a/src/target/new/binary_type.cpp
+++ b/src/target/new/binary_type.cpp
@@ -121,6 +121,24 @@ auto kdl::build_target::binary_type_for_name(const std::string name) -> enum bin
 //        auto width = static_cast<uint32_t>(std::stoul(name.substr(1), nullptr, 16));
 //        return static_cast<binary_type>(static_cast<uint32_t>(P0nn) | width);
 //    }
+    else if (name == "OCNT") {
+        return binary_type::OCNT;
+    }
+//    else if (name == "LSTZ") {
+//        return binary_type::LSTZ;
+//    }
+//    else if (name == "LSTE") {
+//        return binary_type::LSTE;
+//    }
+//    else if (name == "ZCNT") {
+//        return binary_type::ZCNT;
+//    }
+//    else if (name == "LSTC") {
+//        return binary_type::LSTC;
+//    }
+//    else if (name == "LSTB") {
+//        return binary_type::LSTB;
+//    }
 
     return binary_type::INVALID;
 };
@@ -135,7 +153,8 @@ auto kdl::build_target::binary_type_base_size(enum binary_type type) -> std::siz
             return 1;
         }
         case binary_type::HWRD:
-        case binary_type::DWRD: {
+        case binary_type::DWRD:
+        case binary_type::OCNT: {
             return 2;
         }
         case binary_type::HLNG:

--- a/src/target/new/binary_type.hpp
+++ b/src/target/new/binary_type.hpp
@@ -76,6 +76,15 @@ namespace kdl { namespace build_target {
         RECT = 0x001E0000,
 //        Hnnn = 0x001F0000,
 //        P0nn = 0x00200000,
+
+        // List support
+        OCNT = 0x00210000,
+//        LSTZ = 0x00220000,
+//        LSTE = 0x00230000,
+//        ZCNT = 0x00240000,
+//        LSTC = 0x00250000,
+//        LSTB = 0x00260000,
+
     };
 
     auto binary_type_for_name(const std::string name) -> enum binary_type;

--- a/src/target/new/resource_instance.cpp
+++ b/src/target/new/resource_instance.cpp
@@ -23,7 +23,6 @@
 #include "target/new/resource_instance.hpp"
 #include "libGraphite/data/writer.hpp"
 
-
 // MARK: - Constructors
 
 kdl::build_target::resource_instance::resource_instance(const int64_t id, const std::string code,
@@ -103,7 +102,14 @@ auto kdl::build_target::resource_instance::index_of(const std::string field) con
 
 auto kdl::build_target::resource_instance::write(const std::string field, std::any value) -> void
 {
-    m_values[index_of(field)] = value;
+    auto index = index_of(field);
+    if (m_values.find(index) == m_values.end()) {
+        std::vector<std::any> vec({ value });
+        m_values[index] = vec;
+    }
+    else {
+        m_values[index].emplace_back(value);
+    }
 }
 
 auto kdl::build_target::resource_instance::write_byte(const type_field field, const type_field_value field_value, const uint8_t value) -> void
@@ -183,6 +189,77 @@ auto kdl::build_target::resource_instance::write_rect(const type_field field, co
 
 // MARK: - Assembly
 
+auto kdl::build_target::resource_instance::assemble_field(graphite::data::writer& writer, const enum binary_type type, std::any wrapped_value) const -> void
+{
+    switch (type & ~0xFFF) {
+        case build_target::HBYT: {
+            writer.write_byte(std::any_cast<uint8_t>(wrapped_value));
+            break;
+        }
+        case build_target::HWRD: {
+            writer.write_short(std::any_cast<uint16_t>(wrapped_value));
+            break;
+        }
+        case build_target::HLNG: {
+            writer.write_long(std::any_cast<uint32_t>(wrapped_value));
+            break;
+        }
+        case build_target::HQAD: {
+            writer.write_quad(std::any_cast<uint64_t>(wrapped_value));
+            break;
+        }
+        case build_target::DBYT: {
+            writer.write_signed_byte(std::any_cast<int8_t>(wrapped_value));
+            break;
+        }
+        case build_target::DWRD: {
+            writer.write_signed_short(std::any_cast<int16_t>(wrapped_value));
+            break;
+        }
+        case build_target::DLNG: {
+            writer.write_signed_long(std::any_cast<int32_t>(wrapped_value));
+            break;
+        }
+        case build_target::DQAD: {
+            writer.write_signed_quad(std::any_cast<int64_t>(wrapped_value));
+            break;
+        }
+        case build_target::RECT: {
+            auto rect = std::any_cast<std::tuple<int16_t, int16_t, int16_t, int16_t>>(wrapped_value);
+            writer.write_signed_short(std::get<0>(rect));
+            writer.write_signed_short(std::get<1>(rect));
+            writer.write_signed_short(std::get<2>(rect));
+            writer.write_signed_short(std::get<3>(rect));
+            break;
+        }
+        case build_target::HEXD: {
+            if (wrapped_value.type() == typeid(std::vector<char>)) {
+                auto bytes = std::any_cast<std::vector<char>>(wrapped_value);
+                writer.write_bytes(bytes);
+            }
+            else if (wrapped_value.type() == typeid(std::vector<uint8_t>)) {
+                auto bytes = std::any_cast<std::vector<uint8_t>>(wrapped_value);
+                writer.write_bytes(bytes);
+            }
+            break;
+        }
+        case build_target::PSTR:{
+            auto pstr = std::any_cast<std::tuple<std::size_t, std::string>>(wrapped_value);
+            writer.write_pstr(std::get<1>(pstr));
+            break;
+        }
+        case build_target::Cnnn:
+        case build_target::CSTR: {
+            auto cstr = std::any_cast<std::tuple<std::size_t, std::string>>(wrapped_value);
+            writer.write_cstr(std::get<1>(cstr), std::get<0>(cstr));
+            break;
+        }
+        default: {
+            throw std::logic_error("Type not handled");
+        }
+    }
+}
+
 auto kdl::build_target::resource_instance::assemble() const -> std::shared_ptr<graphite::data::data>
 {
     auto data = std::make_shared<graphite::data::data>();
@@ -194,79 +271,34 @@ auto kdl::build_target::resource_instance::assemble() const -> std::shared_ptr<g
         auto field_name = field.label;
         auto index = index_of(field_name.text());
 
-        if (m_values.find(index) == m_values.end()) {
-            writer.write_byte(0, build_target::binary_type_base_size(type));
-            continue;
+        if ((type & ~0xFFF) == build_target::OCNT) {
+            // TODO:
+            // We use an OCNT field to indicate that the next field is repeatable -- this is not really correct as
+            // TMPL resources use LSTC and LSTE in addition to the count field to specify that multiple elements
+            // form a repeating block, and repeating blocks can in turn contain other lists. However just using the
+            // OCNT field is sufficient for STR# resources, which are the only ones we're concerned about at this point.
+            if (m_values.find(index + 1) == m_values.end()) {
+                writer.write_short(0);
+            }
+            else {
+                const auto list_values = m_values.at(index + 1);
+                auto value_field = m_tmpl.binary_field_at(n + 1);
+                auto value_type = value_field.type;
+                writer.write_short(list_values.size());
+                for (const auto& value: list_values) {
+                    assemble_field(writer, value_type, value);
+                }
+            }
+
+            // Increment the field index to skip over the list value field, as that was written out above
+            n++;
         }
-
-        auto wrapped_value = m_values.at(index);
-
-        switch (type & ~0xFFF) {
-            case build_target::HBYT: {
-                writer.write_byte(std::any_cast<uint8_t>(wrapped_value));
-                break;
-            }
-            case build_target::HWRD: {
-                writer.write_short(std::any_cast<uint16_t>(wrapped_value));
-                break;
-            }
-            case build_target::HLNG: {
-                writer.write_long(std::any_cast<uint32_t>(wrapped_value));
-                break;
-            }
-            case build_target::HQAD: {
-                writer.write_quad(std::any_cast<uint64_t>(wrapped_value));
-                break;
-            }
-            case build_target::DBYT: {
-                writer.write_signed_byte(std::any_cast<int8_t>(wrapped_value));
-                break;
-            }
-            case build_target::DWRD: {
-                writer.write_signed_short(std::any_cast<int16_t>(wrapped_value));
-                break;
-            }
-            case build_target::DLNG: {
-                writer.write_signed_long(std::any_cast<int32_t>(wrapped_value));
-                break;
-            }
-            case build_target::DQAD: {
-                writer.write_signed_quad(std::any_cast<int64_t>(wrapped_value));
-                break;
-            }
-            case build_target::RECT: {
-                auto rect = std::any_cast<std::tuple<int16_t, int16_t, int16_t, int16_t>>(wrapped_value);
-                writer.write_signed_short(std::get<0>(rect));
-                writer.write_signed_short(std::get<1>(rect));
-                writer.write_signed_short(std::get<2>(rect));
-                writer.write_signed_short(std::get<3>(rect));
-                break;
-            }
-            case build_target::HEXD: {
-                if (wrapped_value.type() == typeid(std::vector<char>)) {
-                    auto bytes = std::any_cast<std::vector<char>>(wrapped_value);
-                    writer.write_bytes(bytes);
-                }
-                else if (wrapped_value.type() == typeid(std::vector<uint8_t>)) {
-                    auto bytes = std::any_cast<std::vector<uint8_t>>(wrapped_value);
-                    writer.write_bytes(bytes);
-                }
-                break;
-            }
-            case build_target::PSTR:{
-                auto pstr = std::any_cast<std::tuple<std::size_t, std::string>>(wrapped_value);
-                writer.write_pstr(std::get<1>(pstr));
-                break;
-            }
-            case build_target::Cnnn:
-            case build_target::CSTR: {
-                auto cstr = std::any_cast<std::tuple<std::size_t, std::string>>(wrapped_value);
-                writer.write_cstr(std::get<1>(cstr), std::get<0>(cstr));
-                break;
-            }
-            default: {
-                throw std::logic_error("Type not handled");
-            }
+        else if (m_values.find(index) == m_values.end()) {
+            // No value defined so zero out the space allocated to this field
+            writer.write_byte(0, build_target::binary_type_base_size(type));
+        }
+        else {
+            assemble_field(writer, type, m_values.at(index).back());
         }
     }
 
@@ -288,7 +320,7 @@ auto kdl::build_target::resource_instance::synthesize_variables() const -> std::
         if (m_values.find(index) == m_values.end()) {
             continue;
         }
-        auto wrapped_value = m_values.at(index);
+        auto wrapped_value = m_values.at(index).back();
 
         switch (field.type & ~0xFFF) {
             case build_target::HBYT: {

--- a/src/target/new/resource_instance.hpp
+++ b/src/target/new/resource_instance.hpp
@@ -29,7 +29,9 @@
 #include "parser/lexeme.hpp"
 #include "target/new/type_template.hpp"
 #include "target/new/type_field.hpp"
+#include "target/new/binary_type.hpp"
 #include "libGraphite/data/data.hpp"
+#include "libGraphite/data/writer.hpp"
 
 namespace kdl { namespace build_target {
 
@@ -41,8 +43,9 @@ namespace kdl { namespace build_target {
         std::string m_name { "" };
         std::map<std::string, int> m_field_counts;
         type_template m_tmpl;
-        std::map<int, std::any> m_values;
+        std::map<int, std::vector<std::any>> m_values;
 
+        auto assemble_field(graphite::data::writer& writer, const enum binary_type type, std::any wrapped_value) const -> void;
         auto write(const std::string field, std::any value) -> void;
         auto index_of(const std::string field) const -> int;
         auto available_name_extensions(const type_field field) const -> std::map<std::string, lexeme>;


### PR DESCRIPTION
Adds the `OCNT` binary field type and includes placeholders for the other list-related types used in the `TMPL` resource. 

The `resource_instance` binary field value store is extended to use a vector for each field, allowing multiple values to be associated with each.

This deviates from actual list support in `TMPL` resources because only a single repeating binary field is permitted, and `LSTB`/`LSTE` fields are not used. However it's enough to support the `STR#` resource, and this approach could be extended to support the more complex list types used by other resources.

Resolves #11.

Example `STR#` declaration:

```
@type StringList : "STR#" {
    template {
        OCNT stringcount;
        PSTR string;
    };

    field("String") repeatable<0, 65535> {
        string;
    };
};

declare StringList {
    new(#128) {
        String = "a";
        String = "b";
        String = "c";
    };
};
```

Result:

<img width="501" alt="Screen Shot 2020-04-22 at 23 20 16 " src="https://user-images.githubusercontent.com/148661/79986710-d55e5200-84ef-11ea-844f-a5f25f32858a.png">

