### PR TITLE
Add 'snd ' resource support

### DIFF
--- a/src/media/conversion.cpp
+++ b/src/media/conversion.cpp
@@ -21,9 +21,11 @@
 #include "media/conversion.hpp"
 #include "media/image/tga.hpp"
 #include "media/image/png.hpp"
+#include "media/sound/wav.hpp"
 #include "libGraphite/quickdraw/pict.hpp"
 #include "libGraphite/quickdraw/cicn.hpp"
 #include "libGraphite/quickdraw/rle.hpp"
+#include "libGraphite/resources/sound.hpp"
 #include "diagnostic/fatal.hpp"
 
 // MARK: - Constructor
@@ -39,32 +41,47 @@ kdl::media::conversion::conversion(const std::string m_input_file_contents, cons
 
 auto kdl::media::conversion::perform_conversion() const -> std::vector<char>
 {
-    std::shared_ptr<graphite::qd::surface> surface;
-    if (m_input_file_format.is("TGA")) {
-        image::tga tga(m_input_file_contents);
-        surface = tga.surface().lock();
+    if ((m_input_file_format.is("TGA") || m_input_file_format.is("PNG")) &&
+            (m_output_file_format.is("PICT") || m_output_file_format.is("cicn"))) {
+        // Handle image-to-image conversions
+        std::shared_ptr<graphite::qd::surface> surface;
+        if (m_input_file_format.is("TGA")) {
+            image::tga tga(m_input_file_contents);
+            surface = tga.surface().lock();
+        }
+        else if (m_input_file_format.is("PNG")) {
+            image::png png(m_input_file_contents);
+            surface = png.surface().lock();
+        }
+        else {
+            log::fatal_error(m_input_file_format, 1, "Unable to handle input format '" + m_input_file_format.text() + "'");
+        }
+
+        if (m_output_file_format.is("PICT")) {
+            graphite::qd::pict pict(surface);
+            auto pict_data = pict.data();
+
+            return std::vector<char>(pict_data->get()->begin(), pict_data->get()->end());
+        }
+        else if (m_output_file_format.is("cicn")) {
+            graphite::qd::cicn cicn(surface);
+            auto cicn_data = cicn.data();
+
+            return std::vector<char>(cicn_data->get()->begin(), cicn_data->get()->end());
+        }
+        else {
+            log::fatal_error(m_output_file_format, 1, "Unable to handle output format '" + m_output_file_format.text() + "'");
+        }
     }
-    else if (m_input_file_format.is("PNG")) {
-        image::png png(m_input_file_contents);
-        surface = png.surface().lock();
+    else if (m_input_file_format.is("WAV") && m_output_file_format.is("snd")) {
+        sound::wav wav(m_input_file_contents);
+        graphite::resources::sound snd(wav.sample_rate(), wav.sample_bits(), wav.samples());
+        auto snd_data = snd.data();
+
+        return std::vector<char>(snd_data->get()->begin(), snd_data->get()->end());
     }
     else {
-        log::fatal_error(m_input_file_format, 1, "Unable to handle input format '" + m_input_file_format.text() + "'");
-    }
-
-    if (m_output_file_format.is("PICT")) {
-        graphite::qd::pict pict(surface);
-        auto pict_data = pict.data();
-
-        return std::vector<char>(pict_data->get()->begin(), pict_data->get()->end());
-    }
-    else if (m_output_file_format.is("cicn")) {
-        graphite::qd::cicn cicn(surface);
-        auto cicn_data = cicn.data();
-
-        return std::vector<char>(cicn_data->get()->begin(), cicn_data->get()->end());
-    }
-    else {
-        log::fatal_error(m_output_file_format, 1, "Unable to handle output format '" + m_output_file_format.text() + "'");
+        log::fatal_error(m_output_file_format, 1, "Unable to convert from '" + m_input_file_format.text() +
+                         "' to '" + m_output_file_format.text() + "'");
     }
 }

--- a/src/media/sound/wav.cpp
+++ b/src/media/sound/wav.cpp
@@ -1,0 +1,207 @@
+// Copyright (c) 2019-2020 Tom Hancocks
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <iostream>
+#include "wav.hpp"
+
+// MARK: - Constructors
+
+kdl::media::sound::wav::wav(const std::string path)
+{
+    graphite::data::reader reader(path);
+
+    // TODO: Possibly handle any errors that occur?
+    decode(reader);
+}
+
+kdl::media::sound::wav::wav(std::shared_ptr<std::vector<char>> data)
+    : m_sample_rate(1), m_sample_bits(8)
+{
+    auto ptr = std::make_shared<graphite::data::data>(data, data->size(), 0, graphite::data::data::lsb);
+    graphite::data::reader reader(ptr, 0);
+    decode(reader);
+}
+
+kdl::media::sound::wav::wav(uint32_t sample_rate, uint8_t sample_bits, std::vector<std::vector<uint32_t>> sample_data)
+    : m_sample_rate(sample_rate), m_sample_bits(sample_bits), m_sample_data(sample_data)
+{
+
+}
+
+// MARK: - Decoding
+
+auto kdl::media::sound::wav::find_chunk(graphite::data::reader& reader, uint64_t end_position, std::string chunk_id) -> bool
+{
+    while (reader.position() + 4 < end_position) {
+        auto chunk_type = reader.read_cstr(4);
+        if (chunk_type != chunk_id) {
+            auto chunk_size = reader.read_long();
+            reader.move(chunk_size);
+        } else {
+            return true;
+        }
+    }
+    return false;
+}
+
+auto kdl::media::sound::wav::decode(graphite::data::reader &reader) -> bool
+{
+    if (reader.read_cstr(4) != "RIFF") {
+        std::cerr << "WAV Decoder: Expected 'RIFF' chunk" << std::endl;
+        return false;
+    }
+
+    auto end_position = reader.read_long() + reader.position();
+
+    if (reader.read_cstr(4) != "WAVE") {
+        std::cerr << "WAV Decoder: Expected 'WAVE' format" << std::endl;
+        return false;
+    }
+
+    if (!find_chunk(reader, end_position, "fmt ")) {
+        std::cerr << "WAV Decoder: Expected 'fmt ' subchunk" << std::endl;
+        return false;
+    }
+
+    fmt_subchunk_header fmt;
+    fmt.size = reader.read_long();
+    fmt.audio_format = reader.read_short();
+    if (fmt.audio_format != 1 || fmt.size != 16) {
+        std::cerr << "WAV Decoder: Expected PCM file (format 1, size 16; got format " + std::to_string(fmt.audio_format) +
+                     ", size " + std::to_string(fmt.size) + ")" << std::endl;
+        return false;
+    }
+
+    fmt.num_channels = reader.read_short();
+    fmt.sample_rate = reader.read_long();
+    fmt.byte_rate = reader.read_long();
+    fmt.block_align = reader.read_short();
+    fmt.bits_per_sample = reader.read_short();
+
+    if (!find_chunk(reader, end_position, "data")) {
+        std::cerr << "WAV Decoder: Expected 'fmt ' subchunk" << std::endl;
+        return false;
+    }
+
+    auto data_size = reader.read_long();
+    auto num_samples = data_size / fmt.block_align;
+    auto bytes_per_sample = fmt.bits_per_sample / 8;
+    auto sample_offset = fmt.bits_per_sample == 8 ? 0 : (1 << (fmt.bits_per_sample - 1));
+
+    m_sample_bits = fmt.bits_per_sample;
+    m_sample_rate = fmt.sample_rate;
+    m_sample_data.resize(fmt.num_channels, std::vector<uint32_t>(num_samples));
+
+    for (auto s = 0; s < num_samples; s++) {
+        auto sample_start = reader.position();
+
+        for (auto c = 0; c < fmt.num_channels; c++) {
+            m_sample_data[c][s] = 0;
+            for (auto b = 0; b < bytes_per_sample; b++) {
+                m_sample_data[c][s] |= reader.read_byte() << (b * 8);
+            }
+            if (bytes_per_sample > 1 && m_sample_data[c][s] > sample_offset) {
+                // Sign-extend for any value above 8 bits
+                m_sample_data[c][s] |= 0xFFFFFFFF << fmt.bits_per_sample;
+            }
+            // Add the sample offset to map the signed range onto the equivalent unsigned range
+            m_sample_data[c][s] = static_cast<int64_t>(m_sample_data[c][s]) + sample_offset;
+        }
+
+        // Move forward by the block align byte count -- may be different to the actual sample bytes
+        reader.set_position(sample_start + fmt.block_align);
+    }
+
+    // Finished
+    return true;
+}
+
+// MARK: - Encoding
+
+auto kdl::media::sound::wav::encode(graphite::data::writer &writer) -> void
+{
+    writer.data()->set_byte_order(graphite::data::data::byte_order::lsb);
+
+    auto num_channels = m_sample_data.size();
+    if (!num_channels) {
+        return;
+    }
+
+    auto num_samples = m_sample_data[0].size();
+    auto sample_bytes = m_sample_bits / 8;
+    auto sample_offset = 1 << (m_sample_bits - 1);
+
+    // Header
+    writer.write_cstr("RIFF", 4);
+    writer.write_long(36 + sample_bytes * num_channels * num_samples);
+    writer.write_cstr("WAVE", 4);
+
+    // FMT subchunk
+    writer.write_cstr("fmt ", 4);
+    writer.write_long(16); // SubChunk1Size
+    writer.write_short(1); // PCM is format 1
+    writer.write_short(num_channels);
+    writer.write_long(m_sample_rate);
+    writer.write_long(m_sample_rate * num_channels * sample_bytes); // byte rate
+    writer.write_short(num_channels * sample_bytes); // block align
+    writer.write_short(m_sample_bits);
+
+    // data subchunk
+    writer.write_cstr("data", 4);
+    writer.write_long(m_sample_bits / 8 * num_samples * num_channels);
+    for (auto s = 0; s < num_samples; s++) {
+        for (auto c : m_sample_data) {
+            int32_t sample = static_cast<int64_t>(c[s]) - sample_offset;
+
+            if (m_sample_bits == 8) {
+                // Byte range is 0 -> 255, midpoint 128
+                writer.write_byte(static_cast<uint8_t>(c[s]));
+            }
+            else if (m_sample_bits == 16) {
+                // Range -32768 -> 32767, midpoint 0
+                writer.write_signed_short(sample);
+            }
+            else if (m_sample_bits == 24) {
+                // Range -8338608 -> 8338607, midpoint 0
+                writer.write_byte(sample & 0xFF);
+                writer.write_byte((sample >> 8) & 0xFF);
+                writer.write_byte((sample >> 16) & 0xFF);
+            }
+            else if (m_sample_bits == 32) {
+                // Range -2147483648 -> 2147483647, midpoint 0
+                writer.write_signed_long(sample);
+            }
+        }
+    }
+}
+
+// MARK: - Accessors
+
+auto kdl::media::sound::wav::sample_bits() -> uint8_t {
+    return m_sample_bits;
+}
+
+auto kdl::media::sound::wav::sample_rate() -> uint32_t {
+    return m_sample_rate;
+}
+
+auto kdl::media::sound::wav::samples() -> std::vector<std::vector<uint32_t>> {
+    return m_sample_data;
+}

--- a/src/media/sound/wav.hpp
+++ b/src/media/sound/wav.hpp
@@ -1,0 +1,82 @@
+// Copyright (c) 2019-2020 Tom Hancocks
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#if !defined(KDL_WAV_HPP)
+#define KDL_WAV_HPP
+
+#include <vector>
+#include "libGraphite/data/data.hpp"
+#include "libGraphite/data/reader.hpp"
+#include "libGraphite/data/writer.hpp"
+
+namespace kdl { namespace media { namespace sound {
+
+    /**
+     * The `kdl::media::sound::wav` class allows reading of WAV audio files
+     */
+    class wav
+    {
+    protected:
+        struct riff_chunk_header {
+            uint8_t id[4];
+            uint32_t size;
+            uint8_t format[4];
+        };
+
+        struct fmt_subchunk_header {
+            uint8_t id[4];
+            uint32_t size;
+
+            uint16_t audio_format;
+            uint16_t num_channels;
+            uint32_t sample_rate;
+            uint32_t byte_rate;
+            uint16_t block_align;
+            uint16_t bits_per_sample;
+        };
+
+        struct data_subchunk_header {
+            uint8_t id[4];
+            uint32_t size;
+            // Data follows
+        };
+
+    private:
+        uint32_t m_sample_rate;
+        uint8_t m_sample_bits;
+        std::vector<std::vector<uint32_t>> m_sample_data;
+
+        auto decode(graphite::data::reader& reader) -> bool;
+        auto encode(graphite::data::writer& writer) -> void;
+        auto find_chunk(graphite::data::reader& reader, uint64_t end_position, std::string chunk_id) -> bool;
+
+    public:
+        wav(const std::string path);
+        wav(std::shared_ptr<std::vector<char>> data);
+        wav(uint32_t sample_rate, uint8_t sample_bits, std::vector<std::vector<uint32_t>> sample_data);
+
+        auto sample_bits() -> uint8_t;
+        auto sample_rate() -> uint32_t;
+        auto samples() -> std::vector<std::vector<uint32_t>>;
+    };
+
+}}};
+
+#endif //KDL_WAV_HPP

--- a/src/parser/sema/type_definition/conversion_parser.cpp
+++ b/src/parser/sema/type_definition/conversion_parser.cpp
@@ -47,6 +47,8 @@ auto kdl::sema::conversion_parser::parse() -> std::tuple<lexeme, lexeme>
     list.add_valid_list_item(lexeme::identifier, "cicn");
     list.add_valid_list_item(lexeme::identifier, "rleD");
     list.add_valid_list_item(lexeme::identifier, "ppat");
+    list.add_valid_list_item(lexeme::identifier, "WAV");
+    list.add_valid_list_item(lexeme::identifier, "snd");
     list.add_valid_list_item(lexeme::var, "InputFormat");
     auto v = list.parse();
 


### PR DESCRIPTION
Includes support for reading and writing of WAV files, conversion to Mac 'snd ' resources, and the appropriate KDL options to permit specification of the desired conversion.