### PR TITLE
Add 'rleD' encoding support

### DIFF
--- a/src/media/conversion.hpp
+++ b/src/media/conversion.hpp
@@ -29,12 +29,15 @@ namespace kdl { namespace media {
     class conversion
     {
     private:
-        std::shared_ptr<std::vector<char>> m_input_file_contents;
+        std::vector<std::shared_ptr<std::vector<char>>> m_input_file_contents;
         lexeme m_input_file_format;
         lexeme m_output_file_format;
 
     public:
         conversion(const std::string m_input_file_contents, const lexeme input, const lexeme output);
+        conversion(const lexeme input, const lexeme output);
+
+        auto add_input_file(const std::string contents) -> void;
 
         auto perform_conversion() const -> std::vector<char>;
     };

--- a/src/parser/file.cpp
+++ b/src/parser/file.cpp
@@ -9,7 +9,31 @@
 #include <streambuf>
 #include <iostream>
 #include <vector>
+#include <cctype>
+#include <sstream>
+#include <functional>
 #include "parser/file.hpp"
+
+#if true
+// TODO: make this work with Windows
+#define USE_GLOB
+#include <glob.h>
+#endif
+
+// MARK: - Prototypes
+
+int alphanum_impl(const char *l, const char *r);
+
+template<class Ty>
+struct alphanum_less : public std::binary_function<Ty, Ty, bool>
+{
+    bool operator()(const Ty& left, const Ty& right) const
+    {
+        std::ostringstream l; l << left;
+        std::ostringstream r; r << right;
+        return alphanum_impl(l.str().c_str(), r.str().c_str()) < 0;
+    }
+};
 
 // MARK: - Helpers
 
@@ -124,6 +148,31 @@ auto kdl::file::copy_file(std::string_view src, std::string_view dst) -> void
     dst_file << src_file.rdbuf();
 }
 
+auto kdl::file::glob(std::string path) -> std::shared_ptr<std::vector<std::string>>
+{
+    auto files = std::make_shared<std::vector<std::string>>();
+
+#ifdef USE_GLOB
+    glob_t result;
+    int err = ::glob(path.c_str(), GLOB_ERR | GLOB_MARK, NULL, &result);
+
+    for (auto f = 0; f < result.gl_pathc; f++) {
+        std::string fpath(result.gl_pathv[f]);
+        if (fpath.back() != '/') {  // Skip directories
+            files->emplace_back(fpath);
+        }
+    }
+
+    globfree(&result);
+#else
+    // TODO: make this work with Windows
+#endif
+
+    std::sort(files->begin(), files->end(), alphanum_less<std::string>());
+
+    return files;
+}
+
 // MARK: - Constructors
 
 kdl::file::file()
@@ -184,4 +233,96 @@ auto kdl::file::save(std::optional<std::string> path) -> void
     std::ofstream out(m_path);
     out << m_contents;
     out.close();
+}
+
+// MARK: - Alphanum Sort Implementation
+
+/*
+The Alphanum Algorithm is an improved sorting algorithm for strings
+containing numbers.  Instead of sorting numbers in ASCII order like a
+standard sort, this algorithm sorts numbers in numeric order.
+The Alphanum Algorithm is discussed at http://www.DaveKoelle.com
+This implementation is Copyright (c) 2008 Dirk Jagdmann <doj@cubic.org>.
+It is a cleanroom implementation of the algorithm and not derived by
+other's works. In contrast to the versions written by Dave Koelle this
+source code is distributed with the libpng/zlib license.
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any damages
+arising from the use of this software.
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+        1. The origin of this software must not be misrepresented; you
+             must not claim that you wrote the original software. If you use
+             this software in a product, an acknowledgment in the product
+             documentation would be appreciated but is not required.
+        2. Altered source versions must be plainly marked as such, and
+             must not be misrepresented as being the original software.
+        3. This notice may not be removed or altered from any source
+             distribution. */
+
+/**
+     compare l and r with strcmp() semantics, but using
+     the "Alphanum Algorithm". This function is designed to read
+     through the l and r strings only one time, for
+     maximum performance. It does not allocate memory for
+     substrings. It can either use the C-library functions isdigit()
+     and atoi() to honour your locale settings, when recognizing
+     digit characters when you "#define ALPHANUM_LOCALE=1" or use
+     it's own digit character handling which only works with ASCII
+     digit characters, but provides better performance.
+     @param l NULL-terminated C-style string
+     @param r NULL-terminated C-style string
+     @return negative if l<r, 0 if l equals r, positive if l>r
+ */
+int alphanum_impl(const char *l, const char *r)
+{
+    enum mode_t { STRING, NUMBER } mode = STRING;
+
+    while (*l && *r) {
+        if (mode == STRING) {
+            char l_char, r_char;
+            while ((l_char = *l) && (r_char = *r)) {
+                // check if this are digit characters
+                const bool l_digit = isdigit(l_char), r_digit = isdigit(r_char);
+                // if both characters are digits, we continue in NUMBER mode
+                if (l_digit && r_digit) {
+                    mode = NUMBER;
+                    break;
+                }
+                // if only the left character is a digit, we have a result
+                if (l_digit) return -1;
+                // if only the right character is a digit, we have a result
+                if (r_digit) return +1;
+                // compute the difference of both characters
+                const int diff = l_char - r_char;
+                // if they differ we have a result
+                if (diff != 0) return diff;
+                // otherwise process the next characters
+                ++l;
+                ++r;
+            }
+        }
+        else { // mode==NUMBER
+            // get the left number
+            char *end;
+            unsigned long l_int = strtoul(l, &end, 0);
+            l = end;
+
+            // get the right number
+            unsigned long r_int = strtoul(r, &end, 0);
+            r = end;
+
+            // if the difference is not equal to zero, we have a comparison result
+            const long diff = l_int - r_int;
+            if (diff != 0) return diff;
+
+            // otherwise we process the next substring in STRING mode
+            mode = STRING;
+        }
+    }
+
+    if (*r) return -1;
+    if (*l) return +1;
+    return 0;
 }

--- a/src/parser/file.hpp
+++ b/src/parser/file.hpp
@@ -6,6 +6,8 @@
 #define KDL_FILE_HPP
 
 #include <string>
+#include <vector>
+#include <memory>
 #include <optional>
 
 namespace kdl
@@ -24,6 +26,7 @@ namespace kdl
         static auto create_intermediate(std::string_view path, bool omit_last = true) -> bool;
         static auto resolve_tilde(std::string_view path) -> std::string;
         static auto copy_file(std::string_view src, std::string_view dst) -> void;
+        static auto glob(std::string path) -> std::shared_ptr<std::vector<std::string>>;
 
     private:
         std::string m_path;


### PR DESCRIPTION
Resolves #10 

Permits `conversion` objects to accept multiple input files (currently only used for `PNG`/`TGA` -> `rleD`).

Adds support for multiple files to the `import` directive, including glob support on Mac/Linux. (Windows glob support is TODO.) Imported files use natural sort (zlib-licensed) to ensure that filename sequences containing numbers are sorted in ascending order.