### PR TITLE
Add PixelPattern type

### DIFF
--- a/Support/KDLTypes/Toolbox/PixelPattern.kdl
+++ b/Support/KDLTypes/Toolbox/PixelPattern.kdl
@@ -1,0 +1,33 @@
+` Copyright (c) 2019-2020 Tom Hancocks
+` 
+` Permission is hereby granted, free of charge, to any person obtaining a copy
+` of this software and associated documentation files (the "Software"), to deal
+` in the Software without restriction, including without limitation the rights
+` to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+` copies of the Software, and to permit persons to whom the Software is
+` furnished to do so, subject to the following conditions:
+` 
+` The above copyright notice and this permission notice shall be included in all
+` copies or substantial portions of the Software.
+` 
+` THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+` IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+` FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+` AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+` LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+` OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+` SOFTWARE.
+
+@type MacintoshPixelPattern : "ppat" {
+	template {
+		HEXD Data;
+	};
+
+	field("PNG") {
+		Data as File<PNG> __conversion($InputFormat, ppat);
+	};
+
+	`field("TGA") {
+	`	Data as File<TGA> __conversion($InputFormat, ppat);
+	`};
+};

--- a/src/media/conversion.cpp
+++ b/src/media/conversion.cpp
@@ -24,6 +24,7 @@
 #include "media/sound/wav.hpp"
 #include "libGraphite/quickdraw/pict.hpp"
 #include "libGraphite/quickdraw/cicn.hpp"
+#include "libGraphite/quickdraw/ppat.hpp"
 #include "libGraphite/quickdraw/rle.hpp"
 #include "libGraphite/resources/sound.hpp"
 #include "diagnostic/fatal.hpp"
@@ -54,7 +55,7 @@ auto kdl::media::conversion::add_input_file(const std::string contents) -> void
 auto kdl::media::conversion::perform_conversion() const -> std::vector<char>
 {
     if ((m_input_file_format.is("TGA") || m_input_file_format.is("PNG")) &&
-            (m_output_file_format.is("PICT") || m_output_file_format.is("cicn"))) {
+            (m_output_file_format.is("PICT") || m_output_file_format.is("cicn") || m_output_file_format.is("ppat"))) {
         if (m_input_file_contents.size() != 1) {
             log::fatal_error(m_output_file_format, 1, "Unable to process more than one input file for format '" + m_output_file_format.text() + "'");
         }
@@ -84,6 +85,12 @@ auto kdl::media::conversion::perform_conversion() const -> std::vector<char>
             auto cicn_data = cicn.data();
 
             return std::vector<char>(cicn_data->get()->begin(), cicn_data->get()->end());
+        }
+        else if (m_output_file_format.is("ppat")) {
+            graphite::qd::ppat ppat(surface);
+            auto ppat_data = ppat.data();
+
+            return std::vector<char>(ppat_data->get()->begin(), ppat_data->get()->end());
         }
         else {
             log::fatal_error(m_output_file_format, 1, "Unable to handle output format '" + m_output_file_format.text() + "'");

--- a/src/parser/sema/util/list_parser.cpp
+++ b/src/parser/sema/util/list_parser.cpp
@@ -79,7 +79,7 @@ auto kdl::sema::list_parser::parse() -> std::vector<lexeme>
     m_parser.ensure({ expectation(m_list_start).be_true() });
     while (m_parser.expect({ expectation(m_list_end).be_false() })) {
         if (!m_parser.expect_any(expectations)) {
-            log::fatal_error(m_parser.peek(), 1, "Unexpected type encountered in list.");
+            log::fatal_error(m_parser.peek(), 1, "Unexpected type '" + m_parser.peek().text() + "' encountered in list.");
         }
         out.emplace_back(m_parser.read());
 


### PR DESCRIPTION
This PR adds support for creating ppat resources with a new PixelPattern type definition.

Relies on TheDiamondProject/Graphite#12.