### PR TITLE
Add GitHub Actions workflows for macOS+Linux builds

### DIFF
--- a/.github/actions/build_linux/Dockerfile
+++ b/.github/actions/build_linux/Dockerfile
@@ -1,0 +1,9 @@
+FROM debian:bullseye-20210208-slim
+
+RUN apt-get update -y -q && \
+  apt-get install -y -q --no-install-recommends build-essential \
+  gcc \
+  cmake && \
+  apt-get clean
+
+ENTRYPOINT ["/github/workspace/.github/actions/build_linux/entrypoint.sh"]

--- a/.github/actions/build_linux/entrypoint.sh
+++ b/.github/actions/build_linux/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -l
+
+cmake -H. -Bbuild
+cmake --build build -- -j2

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,16 @@
+on: [push]
+
+jobs:
+  build:
+    name: Build on Linux
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: |
+          git submodule init
+          git submodule update
+
+      - name: Run build
+        uses: ./.github/actions/build_linux

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,21 @@
+on: [push]
+
+jobs:
+  build:
+    name: Build on macOS
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: |
+          git submodule init
+          git submodule update
+
+      - name: Install depdendencies
+        run: brew install cmake
+
+      - name: Run build
+        run: |
+          cmake -H. -Bbuild
+          cmake --build build -- -j2


### PR DESCRIPTION
Related to EvocationGames/KestrelEngine#46, this PR adds GitHub Actions workflows for kdl that builds the project on macOS and Linux.

The Linux build fails due to the missing include the Linux build on Graphite identified in https://github.com/TheDiamondProject/Graphite/pull/27.